### PR TITLE
fix: TemplateURL をパス形式に変更して早期バリデーションエラーを修正

### DIFF
--- a/src/lambda-stack.yaml
+++ b/src/lambda-stack.yaml
@@ -19,7 +19,7 @@ Resources:
   IamPolicyStack:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub "https://${TemplateBucketName}.s3.${AWS::Region}.amazonaws.com/templates/iam-policy.yaml"
+      TemplateURL: !Sub "https://s3.${AWS::Region}.amazonaws.com/${TemplateBucketName}/templates/iam-policy.yaml"
 
   MylambdaRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Summary
- `AWS::EarlyValidation::ResourceExistenceCheck` によるデプロイ失敗を修正
- ネストスタックの `TemplateURL` を virtual-hosted-style からパス形式に変更
  - 変更前: `https://${Bucket}.s3.${Region}.amazonaws.com/...`
  - 変更後: `https://s3.${Region}.amazonaws.com/${Bucket}/...`

## Test plan
- [ ] deploy CI が正常に完了すること
- [ ] Function URL にアクセスして `{"message":"Hello World!"}` が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)