### PR TITLE
feat: IAM ロールを明示化し、S3 プレフィックスに実行日付を使用

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,9 +68,11 @@ jobs:
       # ③ SAM デプロイ（S3 アップロード・CFn デプロイを一括実行）
       - name: SAM Deploy
         run: |
+          DEPLOY_DATE=$(date +%Y-%m-%d)
           sam deploy \
             --stack-name "${STACK_NAME}" \
             --s3-bucket "${DEPLOY_BUCKET}" \
+            --s3-prefix "${DEPLOY_DATE}" \
             --capabilities CAPABILITY_NAMED_IAM \
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,20 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
+  MyFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: my-func-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -18,8 +32,7 @@ Resources:
       Handler: index.handler
       Runtime: nodejs22.x
       CodeUri: src/lambda/
-      Policies:
-        - AWSLambdaBasicExecutionRole
+      Role: !GetAtt MyFunctionRole.Arn
       FunctionUrlConfig:
         AuthType: NONE
 


### PR DESCRIPTION
- template.yaml: AWS::IAM::Role を明示的に定義し、SAM 自動生成から切り替え
- deploy.yml: --s3-prefix に date +%Y-%m-%d を設定し日付別にアーティファクトを整理