### PR TITLE
fix: RoleName を省略して IAM ロール名の競合を回避

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -14,7 +14,6 @@ Resources:
   MyFunctionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: my-func-role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
明示的な RoleName 指定が既存ロールと競合し
AWS::EarlyValidation::ResourceExistenceCheck に引っかかるため削除。