### PR TITLE
feat: dev/prod でスタック・関数名を分離

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,8 @@ jobs:
     env:
       DEPLOY_BUCKET: ${{ vars.DEPLOY_BUCKET_NAME }}
       AWS_REGION: ${{ vars.AWS_REGION }}
-      STACK_NAME: ${{ vars.CFN_STACK_NAME }}
+      STACK_BASE_NAME: ${{ vars.CFN_STACK_NAME }}
+      ENV_SUFFIX: ${{ (github.event_name == 'workflow_dispatch' && inputs.environment == 'production') && 'prod' || (github.ref_name == 'main') && 'prod' || 'dev' }}
 
     steps:
       - name: Checkout
@@ -69,17 +70,20 @@ jobs:
       - name: SAM Deploy
         run: |
           DEPLOY_DATE=$(date +%Y-%m-%d)
+          STACK_NAME="${STACK_BASE_NAME}-${ENV_SUFFIX}"
           sam deploy \
             --stack-name "${STACK_NAME}" \
             --s3-bucket "${DEPLOY_BUCKET}" \
             --s3-prefix "${DEPLOY_DATE}" \
             --capabilities CAPABILITY_NAMED_IAM \
+            --parameter-overrides Env="${ENV_SUFFIX}" \
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \
             --region "${AWS_REGION}"
 
       - name: Show stack outputs
         run: |
+          STACK_NAME="${STACK_BASE_NAME}-${ENV_SUFFIX}"
           aws cloudformation describe-stacks \
             --stack-name "${STACK_NAME}" \
             --query "Stacks[0].{Status:StackStatus,Outputs:Outputs}" \

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.local.json
+.aws-sam
+samconfig.toml

--- a/docs/deploy-flow.md
+++ b/docs/deploy-flow.md
@@ -1,141 +1,127 @@
-# デプロイフロー
+# デプロイフロー（SAM CLI）
 
-Lambda スタックを AWS にデプロイするまでの手順をまとめます。
+SAM CLI を使って Lambda スタックを AWS にデプロイするまでの手順をまとめます。
 
 ---
 
 ## 全体の流れ
 
 ```
-① デプロイ用 S3 バケットの確認・作成
-        ↓
-② iam-policy.yaml を S3 にアップロード
-        ↓
-③ lambda-stack.yaml を CloudFormation でデプロイ
+① sam build
+      ↓
+② sam deploy
 ```
+
+SAM CLI がデプロイ用 S3 バケットの作成・管理を自動で行うため、事前に S3 バケットを用意する必要はありません。
 
 ---
 
 ## 前提条件
 
 - AWS CLI がインストール済みで認証が通っていること
+- SAM CLI がインストール済みであること（`sam --version` で確認）
 - 対象リージョンへのアクセス権限を持つ IAM ユーザー/ロールを使用していること
 - 以下の権限が必要
-  - `s3:CreateBucket`, `s3:PutObject`, `s3:GetObject`
+  - `s3:*`（SAM が内部で使う S3 バケットの管理）
   - `cloudformation:*`
   - `iam:CreateRole`, `iam:AttachRolePolicy`, `iam:PassRole`
-  - `lambda:CreateFunction`, `lambda:UpdateFunctionCode`
+  - `lambda:*`
 
 ---
 
-## ① デプロイ用 S3 バケットの確認・作成
+## ① sam build
 
-CloudFormation のネストスタックはテンプレートを S3 から読み込む必要があります。
-テンプレート格納専用の S3 バケットを用意します。
+Lambda 関数のソースコードをパッケージングします。
 
 ```bash
-DEPLOY_BUCKET="<デプロイ用バケット名>"
-REGION="ap-northeast-1"
-
-# バケットの存在確認
-if aws s3api head-bucket --bucket "${DEPLOY_BUCKET}" 2>/dev/null; then
-  echo "バケットは既に存在します: ${DEPLOY_BUCKET}"
-else
-  echo "バケットを作成します: ${DEPLOY_BUCKET}"
-  aws s3api create-bucket \
-    --bucket "${DEPLOY_BUCKET}" \
-    --region "${REGION}" \
-    --create-bucket-configuration LocationConstraint="${REGION}"
-
-  # バージョニングを有効化
-  aws s3api put-bucket-versioning \
-    --bucket "${DEPLOY_BUCKET}" \
-    --versioning-configuration Status=Enabled
-fi
+sam build
 ```
 
-> **注意**: バケット名はグローバルで一意である必要があります。
+- `src/lambda/` のソースコードが `.aws-sam/build/` にビルドされます
+- デプロイ前に必ず実行してください
 
 ---
 
-## ② iam-policy.yaml を S3 にアップロード
+## ② sam deploy
 
-ネストスタックとして参照するテンプレートをアップロードします。
-すでにアップロード済みの場合はスキップします。
+CloudFormation スタックとして AWS にデプロイします。
 
 ```bash
-S3_KEY="templates/iam-policy.yaml"
-
-if aws s3 ls "s3://${DEPLOY_BUCKET}/${S3_KEY}" 2>/dev/null | grep -q "iam-policy.yaml"; then
-  echo "iam-policy.yaml は既に存在します。スキップします。"
-else
-  echo "iam-policy.yaml をアップロードします。"
-  aws s3 cp src/iam-policy.yaml "s3://${DEPLOY_BUCKET}/${S3_KEY}"
-fi
+sam deploy
 ```
+
+設定は `samconfig.toml` に保存されているため、追加の引数は不要です。
+
+### 初回実行時（samconfig.toml がない場合）
+
+```bash
+sam deploy --guided
+```
+
+対話形式で設定を入力すると `samconfig.toml` が自動生成されます。
+
+| 項目 | 説明 |
+|---|---|
+| `stack_name` | CloudFormation スタック名（例: `sam-app`） |
+| `resolve_s3 = true` | SAM が自動でデプロイ用 S3 バケットを作成・管理 |
+| `s3_prefix` | S3 バケット内のプレフィックス |
+| `capabilities = CAPABILITY_IAM` | IAM リソースを含む場合に必須 |
+| `region` | デプロイ先リージョン（例: `ap-northeast-1`） |
 
 ---
 
-## ③ lambda-stack.yaml を CloudFormation でデプロイ
+## デプロイ後の確認
 
-```bash
-aws cloudformation deploy \
-  --template-file src/lambda-stack.yaml \
-  --stack-name my-lambda-stack \
-  --capabilities CAPABILITY_NAMED_IAM \
-  --parameter-overrides \
-    TemplateBucketName="${DEPLOY_BUCKET}"
-```
-
-- `CAPABILITY_NAMED_IAM`: IAM リソース（名前付きロール）を含むため必須
-- デプロイ済みスタックへの再実行は差分更新になります
-
-### 状態確認
+### スタックの状態確認
 
 ```bash
 aws cloudformation describe-stacks \
-  --stack-name my-lambda-stack \
+  --stack-name sam-app \
+  --region ap-northeast-1 \
   --query "Stacks[0].StackStatus"
 ```
 
----
+### Lambda Function URL の確認
 
-## CI/CD による自動デプロイ
+```bash
+aws cloudformation describe-stacks \
+  --stack-name sam-app \
+  --region ap-northeast-1 \
+  --query "Stacks[0].Outputs"
+```
 
-GitHub Actions の `production` 環境を使った自動デプロイが設定されています。
-詳細は `.github/workflows/deploy.yml` を参照してください。
+### Lambda の動作確認
 
-### 必要な GitHub 設定
-
-リポジトリの `Settings > Environments > production` に以下を設定します。
-
-| 種別 | キー | 説明 |
-|---|---|---|
-| Secret | `AWS_ACCESS_KEY_ID` | AWS アクセスキー ID |
-| Secret | `AWS_SECRET_ACCESS_KEY` | AWS シークレットアクセスキー |
-| Variable | `AWS_REGION` | デプロイ先リージョン（例: `ap-northeast-1`） |
-| Variable | `DEPLOY_BUCKET_NAME` | デプロイ用 S3 バケット名 |
-| Variable | `CFN_STACK_NAME` | CloudFormation スタック名（例: `my-lambda-stack`） |
-
-### トリガー
-
-| イベント | 動作 |
-|---|---|
-| `main` ブランチへの push | 自動デプロイ |
-| Actions 画面からの手動実行 | 手動デプロイ |
+```bash
+aws lambda invoke \
+  --function-name my-func \
+  --region ap-northeast-1 \
+  /tmp/response.json && cat /tmp/response.json
+```
 
 ---
 
-## ネストスタック構成
+## スタック構成
 
 ```
-lambda-stack.yaml（親スタック）
-  ├─ S3 バケット（Lambda コード格納用）
-  ├─ IamPolicyStack（ネストスタック）
-  │    └─ iam-policy.yaml（子テンプレート）
-  │         └─ LambdaExecutionPolicy（マネージドポリシー）
-  ├─ MylambdaRole（IAM ロール）
-  │    └─ ↑ のポリシーをアタッチ
-  └─ Lambda 関数
-       └─ ↑ のロールを使用
+sam-app（CloudFormation スタック）
+  ├─ MySampleBucket（S3 バケット）
+  ├─ MyFunctionRole（IAM ロール）
+  └─ MyFunction（Lambda 関数 + Function URL）
 ```
+
+`samconfig.toml` が管理する別スタック:
+```
+aws-sam-cli-managed-default（SAM が自動作成）
+  └─ デプロイ用 S3 バケット（Lambda コードのアップロード先）
+```
+
+---
+
+## トラブルシューティング
+
+デプロイ失敗時は [troubleshooting.md](./troubleshooting.md) を参照してください。
+
+よくある失敗原因:
+- 同名のリソース（Lambda 関数名など）が別スタックに存在する → リソース名の競合
+- `sam build` を実行せずに `sam deploy` した → ソースコードが古いまま

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,145 @@
+# トラブルシューティング
+
+SAM CLI / CloudFormation のデプロイで発生した問題と解決策をまとめます。
+
+---
+
+## リソース名の競合による changeset 失敗
+
+### エラーメッセージ
+
+```
+Error: Failed to create changeset for the stack: sam-app, ex: Waiter ChangeSetCreateComplete failed:
+Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED"
+Status: FAILED. Reason: The following hook(s)/validation failed:
+[AWS::EarlyValidation::ResourceExistenceCheck].
+```
+
+### 原因
+
+`template.yaml` に `FunctionName: my-func` のように**リソース名を明示している**場合、
+同名のリソースが別のスタックにすでに存在すると CloudFormation の Early Validation で弾かれる。
+
+```
+既存スタック: my-lambda-stack ─── my-func（Lambda）
+新規スタック: sam-app         ─── my-func（Lambda）← 衝突！
+```
+
+> **Early Validation とは**
+> changeset 作成前に AWS が実施する事前チェック。デプロイを試みる前に既存リソースとの競合を検出する。
+
+### 解決策
+
+#### A. 古いスタックを削除してから再デプロイ（不要なスタックの場合）
+
+```bash
+aws cloudformation delete-stack --stack-name <古いスタック名> --region ap-northeast-1
+# 削除完了を待ってから
+sam deploy
+```
+
+#### B. `FunctionName` を省略して自動生成名にする（複数環境で使いまわす場合）
+
+```yaml
+# ❌ 明示するとスタックをまたいで競合する
+FunctionName: my-func
+
+# ✅ 省略すると CloudFormation が一意な名前を自動生成（例: sam-app-MyFunction-XXXX）
+# FunctionName: の行ごと削除する
+```
+
+#### C. 環境名をプレフィックスにして名前を分ける
+
+```yaml
+Parameters:
+  Environment:
+    Type: String
+    Default: dev
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${Environment}-my-func"
+```
+
+### 確認コマンド
+
+競合しているスタック・関数を事前に調べる:
+
+```bash
+# 既存のスタック一覧
+aws cloudformation list-stacks \
+  --region ap-northeast-1 \
+  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE \
+  --query "StackSummaries[*].[StackName,StackStatus]" \
+  --output table
+
+# 対象の Lambda 関数がどのスタックに属するか
+aws lambda get-function --function-name my-func --region ap-northeast-1
+```
+
+---
+
+## Lambda Function URL が 403 Forbidden を返す
+
+### 症状
+
+デプロイは成功しているが、Function URL にアクセスすると 403 が返る。
+
+```json
+{"Message":"Forbidden. For troubleshoooting Function URL authorization issues, see: ..."}
+```
+
+`aws lambda invoke` で直接呼び出すと正常に動作する。
+
+### 原因
+
+`AWS::Lambda::Url` + `AWS::Lambda::Permission` を別リソースとして定義すると、
+URL と権限の紐付けが意図通りに機能しないケースがある。
+
+### 解決策
+
+SAM ネイティブの `FunctionUrlConfig` を使う。URL の作成と公開権限を SAM が自動的に正しく設定してくれる。
+
+```yaml
+# ❌ 別リソースとして定義する方法（競合が起きやすい）
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    ...
+
+MyFunctionUrlResource:
+  Type: AWS::Lambda::Url
+  Properties:
+    TargetFunctionArn: !Ref MyFunction
+    AuthType: NONE
+
+MyFunctionUrlPermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    FunctionName: !Ref MyFunction
+    Action: lambda:InvokeFunctionUrl
+    Principal: "*"
+    FunctionUrlAuthType: NONE
+
+# ✅ FunctionUrlConfig を使う（SAM 推奨）
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    ...
+    FunctionUrlConfig:
+      AuthType: NONE
+```
+
+Output の取得方法も変わる:
+
+```yaml
+Outputs:
+  FunctionUrl:
+    # ❌ 別リソースから取得する場合
+    Value: !GetAtt MyFunctionUrlResource.FunctionUrl
+
+    # ✅ FunctionUrlConfig を使った場合
+    Value: !GetAtt MyFunction.FunctionUrl
+```

--- a/template.yaml
+++ b/template.yaml
@@ -2,6 +2,14 @@ AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: Lambda 関数・IAM ロール・S3 バケットを作成するスタック
 
+Parameters:
+  Env:
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      - prod
+
 Resources:
   MySampleBucket:
     Type: AWS::S3::Bucket
@@ -27,7 +35,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: my-func
+      FunctionName: !Sub "my-func-${Env}"
       Handler: index.handler
       Runtime: nodejs22.x
       CodeUri: src/lambda/
@@ -38,4 +46,4 @@ Resources:
 Outputs:
   FunctionUrl:
     Description: Lambda Function URL
-    Value: !GetAtt MyFunctionUrl.FunctionUrl
+    Value: !GetAtt MyFunction.FunctionUrl


### PR DESCRIPTION
- template.yaml に Env パラメータ (dev/prod) を追加
- FunctionName を my-func-${Env} に変更
- deploy.yml で ENV_SUFFIX を導出し、スタック名に付与
- sam deploy に --parameter-overrides Env を追加