### PR TITLE
fix: FunctionUrl 参照を修正、スタック名の二重サフィックスを解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - name: SAM Deploy
         run: |
           DEPLOY_DATE=$(date +%Y-%m-%d)
-          STACK_NAME="${STACK_BASE_NAME}-${ENV_SUFFIX}"
+          STACK_NAME="${STACK_BASE_NAME}"
           sam deploy \
             --stack-name "${STACK_NAME}" \
             --s3-bucket "${DEPLOY_BUCKET}" \
@@ -83,7 +83,7 @@ jobs:
 
       - name: Show stack outputs
         run: |
-          STACK_NAME="${STACK_BASE_NAME}-${ENV_SUFFIX}"
+          STACK_NAME="${STACK_BASE_NAME}"
           aws cloudformation describe-stacks \
             --stack-name "${STACK_NAME}" \
             --query "Stacks[0].{Status:StackStatus,Outputs:Outputs}" \

--- a/template.yaml
+++ b/template.yaml
@@ -46,4 +46,4 @@ Resources:
 Outputs:
   FunctionUrl:
     Description: Lambda Function URL
-    Value: !GetAtt MyFunction.FunctionUrl
+    Value: !GetAtt MyFunctionUrl.FunctionUrl


### PR DESCRIPTION
- !GetAtt MyFunction.FunctionUrl → MyFunctionUrl.FunctionUrl に変更 (SAM が FunctionUrlConfig から生成するリソース名に合わせる)
- STACK_NAME の -${ENV_SUFFIX} 付与を削除 (CFN_STACK_NAME は GitHub 環境変数で env 別に管理されているため)